### PR TITLE
feat: add catalog option management

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -4,6 +4,7 @@ import { Header } from '@/layout/header/Header';
 import { Sidebar } from '@/layout/sidebar/Sidebar';
 import { CommentsPage } from '@/pages/comments/Comments';
 import { LoginPage } from '@/pages/login/Login';
+import { BrandsPage, CategoriesPage, ColorsPage, SizesPage, TagsPage } from '@/pages/options/Options';
 import { Orders } from '@/pages/orders/Orders';
 import { ProductPage } from '@/pages/product/Product';
 import { Products } from '@/pages/products/Products';
@@ -48,6 +49,11 @@ const App: React.FC = () => {
                       <Route path="/users" element={<Users />} />
                       <Route path="/products" element={<Products />} />
                       <Route path="/products/:id" element={<ProductPage />} />
+                      <Route path="/categories" element={<CategoriesPage />} />
+                      <Route path="/brands" element={<BrandsPage />} />
+                      <Route path="/tags" element={<TagsPage />} />
+                      <Route path="/colors" element={<ColorsPage />} />
+                      <Route path="/sizes" element={<SizesPage />} />
                       <Route path="/profile" element={<ProfilePage />} />
                       <Route path="/comments" element={<CommentsPage />} />
                       <Route path="*" element={<Navigate to={'/orders'} />} />

--- a/src/layout/sidebar/Sidebar.tsx
+++ b/src/layout/sidebar/Sidebar.tsx
@@ -20,6 +20,18 @@ type MenuItem = Required<MenuProps>['items'][number];
 const items: MenuItem[] = [
   { label: <NavLink to="/orders">Orders</NavLink>, key: '/orders', icon: <ShoppingCartOutlined /> },
   { label: <NavLink to="/products">Products</NavLink>, key: '/products', icon: <ShopOutlined /> },
+  {
+    label: 'Catalog',
+    key: 'catalog',
+    icon: <PieChartOutlined />,
+    children: [
+      { label: <NavLink to="/categories">Categories</NavLink>, key: '/categories' },
+      { label: <NavLink to="/brands">Brands</NavLink>, key: '/brands' },
+      { label: <NavLink to="/tags">Tags</NavLink>, key: '/tags' },
+      { label: <NavLink to="/colors">Colors</NavLink>, key: '/colors' },
+      { label: <NavLink to="/sizes">Sizes</NavLink>, key: '/sizes' },
+    ],
+  },
   { label: <NavLink to="/users">Users</NavLink>, key: '/users', icon: <UserOutlined /> },
   { label: <NavLink to="/comments">Comments</NavLink>, key: '/comments', icon: <CommentOutlined /> },
 ];

--- a/src/pages/options/Options.tsx
+++ b/src/pages/options/Options.tsx
@@ -1,0 +1,155 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { optionsApi, OptionType } from '@/service/options/options.api';
+import { App, Button, Input, Modal, Table } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+
+import styles from './options.module.scss';
+
+interface OptionItem {
+  key: string;
+  id?: number;
+  name: string;
+}
+
+const labels: Record<OptionType, string> = {
+  categories: 'Category',
+  brands: 'Brand',
+  tags: 'Tag',
+  colors: 'Color',
+  sizes: 'Size',
+};
+
+const OptionManager: React.FC<{ type: OptionType }> = ({ type }) => {
+  const { message, modal } = App.useApp();
+  const [items, setItems] = useState<OptionItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<OptionItem | null>(null);
+  const [name, setName] = useState('');
+
+  const fetchItems = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await optionsApi[type].getAll();
+      const data = res.data;
+      const formatted = data.map((item: string | { id: number; name: string }) =>
+        typeof item === 'string'
+          ? { key: item, name: item }
+          : { key: item.id.toString(), id: item.id, name: item.name },
+      );
+      setItems(formatted);
+    } catch {
+      message.error(`Failed to load ${labels[type].toLowerCase()}s`);
+    } finally {
+      setLoading(false);
+    }
+  }, [message, type]);
+
+  useEffect(() => {
+    fetchItems();
+  }, [fetchItems]);
+
+  const handleCreate = () => {
+    setEditingItem(null);
+    setName('');
+    setIsModalOpen(true);
+  };
+
+  const handleEdit = (item: OptionItem) => {
+    setEditingItem(item);
+    setName(item.name);
+    setIsModalOpen(true);
+  };
+
+  const handleDelete = (item: OptionItem) => {
+    modal.confirm({
+      title: `Delete ${labels[type]}`,
+      content: `Are you sure you want to delete this ${labels[type].toLowerCase()}?`,
+      okType: 'danger',
+      onOk: async () => {
+        try {
+          if (item.id !== undefined) {
+            await optionsApi[type].delete(item.id);
+          } else {
+            await optionsApi[type].delete(item.name);
+          }
+          message.success(`${labels[type]} deleted`);
+          fetchItems();
+        } catch {
+          message.error(`Failed to delete ${labels[type].toLowerCase()}`);
+        }
+      },
+    });
+  };
+
+  const handleSubmit = async () => {
+    try {
+      if (editingItem) {
+        if (editingItem.id !== undefined) {
+          await optionsApi[type].update(editingItem.id, { name });
+        } else {
+          await optionsApi[type].update(editingItem.name, { name });
+        }
+        message.success(`${labels[type]} updated`);
+      } else {
+        await optionsApi[type].create({ name });
+        message.success(`${labels[type]} created`);
+      }
+      setIsModalOpen(false);
+      fetchItems();
+    } catch {
+      message.error(`Failed to save ${labels[type].toLowerCase()}`);
+    }
+  };
+
+  const columns: ColumnsType<OptionItem> = [
+    { title: labels[type], dataIndex: 'name', key: 'name' },
+    {
+      title: 'Actions',
+      key: 'actions',
+      render: (_, record) => (
+        <div>
+          <Button size="small" onClick={() => handleEdit(record)} style={{ marginRight: 8 }}>
+            Edit
+          </Button>
+          <Button size="small" danger onClick={() => handleDelete(record)}>
+            Delete
+          </Button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>{labels[type]} Management</h2>
+        <Button type="primary" onClick={handleCreate}>
+          Add {labels[type]}
+        </Button>
+      </div>
+      <Table rowKey="key" columns={columns} dataSource={items} loading={loading} pagination={false} />
+
+      <Modal
+        open={isModalOpen}
+        title={editingItem ? `Edit ${labels[type]}` : `Add ${labels[type]}`}
+        onCancel={() => setIsModalOpen(false)}
+        onOk={handleSubmit}
+      >
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={`Enter ${labels[type].toLowerCase()} name`}
+        />
+      </Modal>
+    </div>
+  );
+};
+
+export const CategoriesPage = () => <OptionManager type="categories" />;
+export const BrandsPage = () => <OptionManager type="brands" />;
+export const TagsPage = () => <OptionManager type="tags" />;
+export const ColorsPage = () => <OptionManager type="colors" />;
+export const SizesPage = () => <OptionManager type="sizes" />;
+
+export default OptionManager;

--- a/src/pages/options/options.module.scss
+++ b/src/pages/options/options.module.scss
@@ -1,0 +1,14 @@
+.container {
+  padding: 24px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.title {
+  margin: 0;
+}

--- a/src/service/options/options.api.ts
+++ b/src/service/options/options.api.ts
@@ -1,0 +1,34 @@
+import axios from 'axios';
+
+import { ApiResponse, BrandProps, CategoryProps, TagProps } from '../service.types';
+
+interface NamePayload {
+  name: string;
+}
+
+const buildResourceApi = (base: string) => ({
+  getAll: (): Promise<ApiResponse<(CategoryProps | BrandProps | TagProps)[]>> => axios.get(`/admin/${base}`),
+  create: (data: NamePayload): Promise<ApiResponse<CategoryProps | BrandProps | TagProps>> =>
+    axios.post(`/admin/${base}`, data),
+  update: (id: number, data: NamePayload): Promise<ApiResponse<CategoryProps | BrandProps | TagProps>> =>
+    axios.patch(`/admin/${base}/${id}`, data),
+  delete: (id: number): Promise<ApiResponse<null>> => axios.delete(`/admin/${base}/${id}`),
+});
+
+const buildSimpleApi = (base: string) => ({
+  getAll: (): Promise<ApiResponse<string[]>> => axios.get(`/admin/${base}`),
+  create: (data: NamePayload): Promise<ApiResponse<string>> => axios.post(`/admin/${base}`, data),
+  update: (oldName: string, data: NamePayload): Promise<ApiResponse<string>> =>
+    axios.patch(`/admin/${base}/${oldName}`, data),
+  delete: (name: string): Promise<ApiResponse<null>> => axios.delete(`/admin/${base}/${name}`),
+});
+
+export const optionsApi = {
+  categories: buildResourceApi('categories'),
+  brands: buildResourceApi('brands'),
+  tags: buildResourceApi('tags'),
+  colors: buildSimpleApi('colors'),
+  sizes: buildSimpleApi('sizes'),
+};
+
+export type OptionType = keyof typeof optionsApi;


### PR DESCRIPTION
## Summary
- add API and UI to manage categories, brands, tags, colors and sizes
- expose new management pages and routes

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892058ecdb4832e914e8540ab9612ad