### PR TITLE
feat: localize timestamps

### DIFF
--- a/src/pages/comments/comments.utils.tsx
+++ b/src/pages/comments/comments.utils.tsx
@@ -1,4 +1,5 @@
 import { ProductComment } from '@/service/service.types';
+import { formatDate, formatDateTime, formatTime } from '@/utils/date';
 import {
   CheckCircleOutlined,
   ClockCircleOutlined,
@@ -7,9 +8,8 @@ import {
   EyeOutlined,
   UserOutlined,
 } from '@ant-design/icons';
-import { Avatar, Button, Select, Space, Tag, Tooltip, Typography } from 'antd';
+import { Avatar, Button, Select, Space, Tooltip, Typography } from 'antd';
 import { ColumnsType } from 'antd/es/table';
-import dayjs from 'dayjs';
 
 const { Text } = Typography;
 const { Option } = Select;
@@ -150,10 +150,10 @@ export const createCommentsColumns = ({
     dataIndex: 'created_at',
     key: 'created_at',
     render: (date: string) => (
-      <Tooltip title={dayjs(date).format('YYYY-MM-DD HH:mm:ss')}>
+      <Tooltip title={formatDateTime(date, { dateStyle: 'medium', timeStyle: 'medium' })}>
         <div>
-          <div style={{ fontWeight: 500 }}>{dayjs(date).format('MM/DD/YY')}</div>
-          <div style={{ fontSize: '12px', color: '#666' }}>{dayjs(date).format('HH:mm')}</div>
+          <div style={{ fontWeight: 500 }}>{formatDate(date)}</div>
+          <div style={{ fontSize: '12px', color: '#666' }}>{formatTime(date)}</div>
         </div>
       </Tooltip>
     ),

--- a/src/pages/comments/components/comment-details/CommentDetails.tsx
+++ b/src/pages/comments/components/comment-details/CommentDetails.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { ProductComment } from '@/service/service.types';
+import { formatDateTime } from '@/utils/date';
 import { CheckOutlined, CloseOutlined, UserOutlined } from '@ant-design/icons';
 import { Avatar, Button, Card, Modal, Space, Tag, Typography } from 'antd';
-import dayjs from 'dayjs';
 
 import styles from './comment-details.module.scss';
 
@@ -146,12 +146,12 @@ export const CommentDetails: React.FC<CommentDetailsModalProps> = ({ open, comme
               </div>
               <div className={styles.metadataRow}>
                 <Text strong>Posted:</Text>
-                <Text>{dayjs(comment.created_at).format('YYYY-MM-DD HH:mm:ss')}</Text>
+                <Text>{formatDateTime(comment.created_at, { dateStyle: 'medium', timeStyle: 'medium' })}</Text>
               </div>
               {comment.updated_at !== comment.created_at && (
                 <div className={styles.metadataRow}>
                   <Text strong>Last Updated:</Text>
-                  <Text>{dayjs(comment.updated_at).format('YYYY-MM-DD HH:mm:ss')}</Text>
+                  <Text>{formatDateTime(comment.updated_at, { dateStyle: 'medium', timeStyle: 'medium' })}</Text>
                 </div>
               )}
             </Space>

--- a/src/pages/orders/components/order-details-modal/OrderDetailsModal.tsx
+++ b/src/pages/orders/components/order-details-modal/OrderDetailsModal.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Order } from '@/service/service.types';
+import { formatDate, formatTime } from '@/utils/date';
 import { CheckCircleOutlined, ClockCircleOutlined, ShoppingCartOutlined, TruckOutlined } from '@ant-design/icons';
-import { Badge, Card, Col, Descriptions, Divider, Modal, Row, Steps, Table, Tag, Typography } from 'antd';
+import { Card, Col, Descriptions, Modal, Row, Steps, Table, Tag, Typography } from 'antd';
 
 const { Title, Text } = Typography;
 
@@ -142,7 +143,7 @@ export const OrderDetailsModal: React.FC<OrderDetailsModalProps> = ({ open, orde
             <Descriptions column={1} size="small">
               <Descriptions.Item label="Order ID">#{order.id}</Descriptions.Item>
               <Descriptions.Item label="Date">
-                {new Date(order.created_at).toLocaleDateString()} {new Date(order.created_at).toLocaleTimeString()}
+                {formatDate(order.created_at)} {formatTime(order.created_at)}
               </Descriptions.Item>
               <Descriptions.Item label="Total Amount">
                 <Text strong style={{ fontSize: '16px' }}>

--- a/src/pages/orders/orders.utils.tsx
+++ b/src/pages/orders/orders.utils.tsx
@@ -1,4 +1,5 @@
 import { Order } from '@/service/service.types';
+import { formatDate, formatTime } from '@/utils/date';
 import {
   CheckCircleOutlined,
   ClockCircleOutlined,
@@ -6,7 +7,7 @@ import {
   ShoppingCartOutlined,
   TruckOutlined,
 } from '@ant-design/icons';
-import { Badge, Button, Select, Space, Tag, Tooltip } from 'antd';
+import { Button, Select, Space, Tag, Tooltip } from 'antd';
 import { ColumnsType } from 'antd/es/table';
 
 const getStatusColor = (status: Order['status']) => {
@@ -160,8 +161,8 @@ export const createOrdersColumns = ({ handleView, handleStatusChange }: OrdersCo
     sorter: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
     render: (date: string) => (
       <div>
-        <div>{new Date(date).toLocaleDateString()}</div>
-        <div style={{ fontSize: '12px', color: '#666' }}>{new Date(date).toLocaleTimeString()}</div>
+        <div>{formatDate(date)}</div>
+        <div style={{ fontSize: '12px', color: '#666' }}>{formatTime(date)}</div>
       </div>
     ),
   },

--- a/src/pages/product/Product.tsx
+++ b/src/pages/product/Product.tsx
@@ -2,9 +2,9 @@ import React, { useEffect, useState } from 'react';
 import { productsApi } from '@/service/products/products.api';
 import { IProduct, ProductComment } from '@/service/service.types';
 import { getFile } from '@/service/service.utils';
+import { formatDateTime } from '@/utils/date';
 import { useParams } from 'react-router';
 import { App, Avatar, Button, Card, Col, Form, Image, Input, List, Row, Space, Tag, Typography } from 'antd';
-import dayjs from 'dayjs';
 
 import styles from './product.module.scss';
 
@@ -137,7 +137,7 @@ export const ProductPage: React.FC = () => {
                     <Text>
                       {item.user?.name} {item.user.last_name}
                     </Text>
-                    <Text type="secondary">{dayjs(item.created_at).format('YYYY-MM-DD HH:mm')}</Text>
+                    <Text type="secondary">{formatDateTime(item.created_at)}</Text>
                   </Space>
                 }
                 description={item.content}

--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { User } from '@/service/service.types';
 import { usersApi } from '@/service/users/users.api';
+import { formatDate } from '@/utils/date';
 import {
   DeleteOutlined,
   EditOutlined,
@@ -13,9 +14,8 @@ import {
   SearchOutlined,
   UserOutlined,
 } from '@ant-design/icons';
-import { App, Avatar, Button, Empty, Input, Modal, Pagination, Select, Spin, Table, Tag, Typography } from 'antd';
+import { App, Avatar, Button, Input, Pagination, Select, Spin, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import dayjs from 'dayjs';
 
 import styles from './users.module.scss';
 
@@ -210,8 +210,8 @@ export const Users: React.FC = () => {
       title: 'Joined',
       dataIndex: 'created_at',
       key: 'created_at',
-      render: (date) => dayjs(date).format('MMM DD, YYYY'),
-      sorter: (a, b) => dayjs(a.created_at).unix() - dayjs(b.created_at).unix(),
+      render: (date) => formatDate(date, { dateStyle: 'medium' }),
+      sorter: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
     },
     {
       title: 'Actions',

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,32 @@
+export const getUserLocale = (): string => (typeof navigator !== 'undefined' ? navigator.language : 'de-DE');
+
+export const getUserTimeZone = (): string =>
+  typeof window !== 'undefined' ? Intl.DateTimeFormat().resolvedOptions().timeZone : 'Europe/Berlin';
+
+export const formatDate = (date: string | number | Date, options: Intl.DateTimeFormatOptions = {}): string => {
+  const d = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
+  return new Intl.DateTimeFormat(getUserLocale(), {
+    timeZone: getUserTimeZone(),
+    dateStyle: 'short',
+    ...options,
+  }).format(d);
+};
+
+export const formatTime = (date: string | number | Date, options: Intl.DateTimeFormatOptions = {}): string => {
+  const d = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
+  return new Intl.DateTimeFormat(getUserLocale(), {
+    timeZone: getUserTimeZone(),
+    timeStyle: 'short',
+    ...options,
+  }).format(d);
+};
+
+export const formatDateTime = (date: string | number | Date, options: Intl.DateTimeFormatOptions = {}): string => {
+  const d = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
+  return new Intl.DateTimeFormat(getUserLocale(), {
+    timeZone: getUserTimeZone(),
+    dateStyle: 'short',
+    timeStyle: 'short',
+    ...options,
+  }).format(d);
+};


### PR DESCRIPTION
## Summary
- add utility to format dates based on browser locale/timezone with German fallback
- use new formatter for order, comment, product and user timestamps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892145532cc832eaf806bc1f33896d8