### PR TITLE
feat: allow comment editing

### DIFF
--- a/src/pages/product/Product.tsx
+++ b/src/pages/product/Product.tsx
@@ -1,8 +1,11 @@
 import React, { useEffect, useState } from 'react';
+import { commentsApi } from '@/service/comments/comments.api';
 import { productsApi } from '@/service/products/products.api';
 import { IProduct, ProductComment } from '@/service/service.types';
 import { getFile } from '@/service/service.utils';
+import { selectAuthUser } from '@/store/auth/auth.selectors';
 import { formatDateTime } from '@/utils/date';
+import { useSelector } from 'react-redux';
 import { useParams } from 'react-router';
 import { App, Avatar, Button, Card, Col, Form, Image, Input, List, Row, Space, Tag, Typography } from 'antd';
 
@@ -21,6 +24,10 @@ export const ProductPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [commentValue, setCommentValue] = useState('');
+  const authUser = useSelector(selectAuthUser);
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+  const [editingContent, setEditingContent] = useState('');
+  const [updating, setUpdating] = useState(false);
 
   const getComments = async (productId: number) => {
     try {
@@ -65,6 +72,32 @@ export const ProductPage: React.FC = () => {
       message.error('Failed to add comment');
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const startEditComment = (comment: ProductComment) => {
+    setEditingCommentId(comment.id);
+    setEditingContent(comment.content);
+  };
+
+  const cancelEditComment = () => {
+    setEditingCommentId(null);
+    setEditingContent('');
+  };
+
+  const handleUpdateComment = async () => {
+    if (editingCommentId === null || !editingContent.trim()) return;
+    try {
+      setUpdating(true);
+      await commentsApi.updateComment(editingCommentId, { content: editingContent });
+      message.success('Comment updated successfully');
+      await getComments(productId);
+      cancelEditComment();
+    } catch (error) {
+      console.error('Failed to update comment:', error);
+      message.error('Failed to update comment');
+    } finally {
+      setUpdating(false);
     }
   };
 
@@ -129,7 +162,27 @@ export const ProductPage: React.FC = () => {
           dataSource={comments}
           locale={{ emptyText: 'No comments yet' }}
           renderItem={(item) => (
-            <List.Item key={item.id}>
+            <List.Item
+              key={item.id}
+              actions={
+                authUser && authUser.id === item.user.id
+                  ? editingCommentId === item.id
+                    ? [
+                        <Button type="link" onClick={handleUpdateComment} loading={updating}>
+                          Save
+                        </Button>,
+                        <Button type="link" onClick={cancelEditComment}>
+                          Cancel
+                        </Button>,
+                      ]
+                    : [
+                        <Button type="link" onClick={() => startEditComment(item)}>
+                          Edit
+                        </Button>,
+                      ]
+                  : undefined
+              }
+            >
               <List.Item.Meta
                 avatar={<Avatar>{item.user?.name?.[0] || 'U'}</Avatar>}
                 title={
@@ -140,7 +193,13 @@ export const ProductPage: React.FC = () => {
                     <Text type="secondary">{formatDateTime(item.created_at)}</Text>
                   </Space>
                 }
-                description={item.content}
+                description={
+                  editingCommentId === item.id ? (
+                    <TextArea rows={2} value={editingContent} onChange={(e) => setEditingContent(e.target.value)} />
+                  ) : (
+                    item.content
+                  )
+                }
               />
               <Tag color={item.status === 'approved' ? 'green' : item.status === 'rejected' ? 'red' : 'orange'}>
                 {item.status}

--- a/src/service/comments/comments.api.ts
+++ b/src/service/comments/comments.api.ts
@@ -10,6 +10,9 @@ export const commentsApi = {
   createComment: (productId: number, data: CreateCommentRequest): Promise<ApiResponse<ProductComment>> =>
     axios.post(`/products/${productId}/comments`, data),
 
+  updateComment: (id: number, data: CreateCommentRequest): Promise<ApiResponse<ProductComment>> =>
+    axios.patch(`/comments/${id}`, data),
+
   // Admin comment management
   admin: {
     // Updated: Remove getPendingComments and use getAllComments with status filter


### PR DESCRIPTION
## Summary
- allow users to edit their own comments
- add API helper for comment updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 2 errors, 23 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68923f2455d4832e94fb213f37a6e5e3