### PR TITLE
feat: show cancelled orders in summary

### DIFF
--- a/src/pages/orders/Orders.tsx
+++ b/src/pages/orders/Orders.tsx
@@ -31,6 +31,7 @@ export const Orders = () => {
     processing: 0,
     shipped: 0,
     delivered: 0,
+    cancelled: 0,
     total_revenue: '0',
   });
 
@@ -92,6 +93,7 @@ export const Orders = () => {
     processing: ordersSummary.processing,
     shipped: ordersSummary.shipped,
     delivered: ordersSummary.delivered,
+    cancelled: ordersSummary.cancelled,
     totalRevenue: ordersSummary.total_revenue,
   };
 
@@ -125,6 +127,11 @@ export const Orders = () => {
         <Col span={4}>
           <Card>
             <Statistic title="Delivered" value={stats.delivered} valueStyle={{ color: '#52c41a' }} />
+          </Card>
+        </Col>
+        <Col span={4}>
+          <Card>
+            <Statistic title="Cancelled" value={stats.cancelled} valueStyle={{ color: '#ff4d4f' }} />
           </Card>
         </Col>
         <Col span={4}>

--- a/src/service/orders/orders.api.ts
+++ b/src/service/orders/orders.api.ts
@@ -39,6 +39,7 @@ export const ordersApi = {
           processing: number;
           shipped: number;
           delivered: number;
+          cancelled: number;
           total_revenue: string;
         };
       }>


### PR DESCRIPTION
## Summary
- include cancelled count in admin order summary API
- display cancelled orders in dashboard statistics

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68929b8d8a08832ebc466ec6bfff550d