### PR TITLE
fix: make orders actions sticky

### DIFF
--- a/src/pages/orders/orders.utils.tsx
+++ b/src/pages/orders/orders.utils.tsx
@@ -175,6 +175,7 @@ export const createOrdersColumns = ({
   {
     title: 'Actions',
     key: 'actions',
+    fixed: 'right',
     width: 100,
     render: (_, record: Order) => (
       <Space size="small">


### PR DESCRIPTION
## Summary
- keep action buttons visible by fixing the Actions column on the Orders Management table

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68929bedc94c832eb5d47c26cc9e4803