### PR TITLE
refactor: use dayjs for date formatting

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,32 +1,62 @@
+import dayjs from 'dayjs';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+
+import 'dayjs/locale/de';
+
+dayjs.extend(localizedFormat);
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
 export const getUserLocale = (): string => (typeof navigator !== 'undefined' ? navigator.language : 'de-DE');
 
 export const getUserTimeZone = (): string =>
   typeof window !== 'undefined' ? Intl.DateTimeFormat().resolvedOptions().timeZone : 'Europe/Berlin';
 
+const dateStyleMap: Record<NonNullable<Intl.DateTimeFormatOptions['dateStyle']>, string> = {
+  short: 'L',
+  medium: 'll',
+  long: 'LL',
+  full: 'dddd, LL',
+};
+
+const timeStyleMap: Record<NonNullable<Intl.DateTimeFormatOptions['timeStyle']>, string> = {
+  short: 'LT',
+  medium: 'LTS',
+  long: 'LTS',
+  full: 'LTS',
+};
+
+const getLocale = (): string => {
+  const locale = getUserLocale().toLowerCase();
+  if ((dayjs as any).Ls[locale]) return locale;
+  const generic = locale.split('-')[0];
+  return (dayjs as any).Ls[generic] ? generic : 'en';
+};
+
+const buildFormat = (
+  defaultDateToken: string,
+  defaultTimeToken: string | undefined,
+  options: Intl.DateTimeFormatOptions = {},
+): string => {
+  const { dateStyle, timeStyle } = options;
+  const dateToken = dateStyle ? dateStyleMap[dateStyle] : defaultDateToken;
+  const timeToken = timeStyle ? timeStyleMap[timeStyle] : defaultTimeToken;
+  return [dateToken, timeToken].filter(Boolean).join(' ');
+};
+
 export const formatDate = (date: string | number | Date, options: Intl.DateTimeFormatOptions = {}): string => {
-  const d = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
-  return new Intl.DateTimeFormat(getUserLocale(), {
-    timeZone: getUserTimeZone(),
-    dateStyle: 'short',
-    ...options,
-  }).format(d);
+  const formatStr = buildFormat('L', undefined, options);
+  return dayjs(date).tz(getUserTimeZone()).locale(getLocale()).format(formatStr);
 };
 
 export const formatTime = (date: string | number | Date, options: Intl.DateTimeFormatOptions = {}): string => {
-  const d = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
-  return new Intl.DateTimeFormat(getUserLocale(), {
-    timeZone: getUserTimeZone(),
-    timeStyle: 'short',
-    ...options,
-  }).format(d);
+  const formatStr = buildFormat('', 'LT', options);
+  return dayjs(date).tz(getUserTimeZone()).locale(getLocale()).format(formatStr);
 };
 
 export const formatDateTime = (date: string | number | Date, options: Intl.DateTimeFormatOptions = {}): string => {
-  const d = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
-  return new Intl.DateTimeFormat(getUserLocale(), {
-    timeZone: getUserTimeZone(),
-    dateStyle: 'short',
-    timeStyle: 'short',
-    ...options,
-  }).format(d);
+  const formatStr = buildFormat('L', 'LT', options);
+  return dayjs(date).tz(getUserTimeZone()).locale(getLocale()).format(formatStr);
 };


### PR DESCRIPTION
## Summary
- refactor date utility to leverage Day.js with timezone and locale handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68929c21aa68832eb65c51a62a153d39